### PR TITLE
Fix malformed pbuild cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Another example more useful than bc calculator is:
 ```
 make upstream_pkg PKG=linux-source-4.15.0
 ```
+```
+make upstream_pkg PKG=keystone
+```
 
 Porting of functional Starling X patches located at:
 

--- a/configs/generic-Makefile
+++ b/configs/generic-Makefile
@@ -1,6 +1,6 @@
 all:
 	sudo rm -rf /var/cache/pbuilder/result/*.deb
-	sudo pbuilder build --override-config *.dsc
+	sudo pbuilder build *.dsc
 	mkdir -p results/
 	sudo cp -rf /var/cache/pbuilder/result/*.deb results/
 	sudo cp results/*.deb /usr/local/mydebs/


### PR DESCRIPTION
This flag is not necesary for upstream packages

Signed-off-by: VictorRodriguez <vm.rod25@gmail.com>