### PR TITLE
Modifying x.stx-fault repo pointer

### DIFF
--- a/repos
+++ b/repos
@@ -1,5 +1,4 @@
 https://github.com/VictorRodriguez/x.stx-upstream.git,master
-https://github.com/VictorRodriguez/x.stx-fault.git,poc_ubuntu_build
+https://github.com/marcelarosalesj/x.stx-fault.git,ubuntu
 https://github.com/marcelarosalesj/x.stx-config.git,ubuntu
-https://github.com/VictorRodriguez/x.stx-upstream.git,master
 https://github.com/MarioCarrilloA/x.stx-update.git,ubuntu


### PR DESCRIPTION
These packages are included for ubuntu deb building:
- fm-common
- fm-mgr
- fm-api
- fm-rest-api

Signed-off-by: Marcela Rosales <marcelarosalesj@gmail.com>