### PR TITLE
Add support for live image creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ iso:
 	cp -rf /usr/local/mydebs/*.deb linuxbuilder/DEBS/
 	cd linuxbuilder/ && make iso-ubuntu IMAGE=$(ISO_TEMPLATE)
 	mv linuxbuilder/ubuntu.iso .
+liveimg:
+	@ echo "Creating $(DISTRO) live image"
+	cp -rf /usr/local/mydebs/*.deb live_img/$(DISTRO)/stxdebs/
+	@ cd live_img/ && make DISTRO=$(DISTRO)
 package:
 	@echo "Building package $(PKG) for $(DISTRO)"
 	cd $(PKG)/$(DISTRO) && make

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,14 @@ else
     cd ..
 fi
 
+if [ ! -d "live_img" ]; then
+    git clone --depth=1 https://github.com/marcelarosalesj/live_img.git
+else
+    echo "Updating live_img"
+    cd live_img/ && git pull
+    cd ..
+fi
+
 # clone source code repos on specific branches
 filename='repos'
 while IFS=, read GIT_REPO BRANCH; do


### PR DESCRIPTION
- The setup.sh will close live_img project, which has the scripts
that creates an ubuntu live image. This is the only one supported
for now.
- It was added a liveimg target to the Makefile.

Signed-off-by: Marcela Rosales <marcelarosalesj@gmail.com>