### PR TITLE
Add missing grub modules

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,10 @@ if [ ! -f /var/cache/pbuilder/base.tgz ] ; then
     sudo pbuilder create
 fi
 
+if [ ! -d "/usr/lib/grub/i386-pc" ]; then
+    sudo apt-get install -y grub-pc
+fi
+
 sudo mkdir -p /usr/local/mydebs/
 sudo mkdir -p /var/cache/pbuilder/hook.d/
 


### PR DESCRIPTION
The grub-pc package includes modules which
allow to an ISO image to boot from a CD-ROM.

Signed-off-by: Mario Alfredo Carrillo Arevalo <mario.alfredo.c.arevalo@intel.com>