### PR TITLE
install dpkg-dev if it does not exist

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,10 @@ if ! type "pbuilder" > /dev/null; then
     sudo apt-get install -y pbuilder
 fi
 
+if ! type "dpkg-scanpackages" > /dev/null; then
+    sudo apt-get install -y dpkg-dev
+fi
+
 if [ ! -f /var/cache/pbuilder/base.tgz ] ; then
     sudo pbuilder create
 fi


### PR DESCRIPTION
This package is not included in minimal ubuntu installation and
causes pbuilder error.

Signed-off-by: Bin Yang <bin.yang@intel.com>