### PR TITLE
Use repo tool to clone all needed repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,25 @@ local machine for development and testing purposes.
 
 ### Prerequisites
 
+To clone this repository the [repo tool](https://source.android.com/setup/develop/repo) is needed. You can install it by running:
+
+```
+curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo && \
+    chmod a+x /usr/local/bin/repo
+```
+
+Then just run:
+
+```
+repo init -u https://github.com/starlingx-staging/stx-packaging -m default.xml
+repo sync -j4
+```
+
 The development tools and git repositories that you need are installed by
 running setup.sh
 
 ```
-bash setup.sh
+./setup.sh
 ```
 
 If you are under a proxy in order to make pbuilder make use of your apt-cache,

--- a/default.xml
+++ b/default.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+	<remote name="stx-staging" fetch="https://github.com/starlingx-staging"/>
+	<remote name="github" fetch="https://github.com/"/>
+
+	<default revision="master" remote="stx-staging"/>
+
+	<project remote="stx-staging" name="stx-packaging.git" path="stx-packaging" />
+
+	<!-- Dependency repositories -->
+	<project remote="github" name="VictorRodriguez/autodeb.git"
+		 path="stx-packaging/autodeb" />
+	<project remote="github" name="VictorRodriguez/linuxbuilder.git"
+		 path="stx-packaging/linuxbuilder" />
+	<project remote="github" name="marcelarosalesj/live_img.git"
+		 path="stx-packaging/live_img" />
+
+	<!-- Source code repositories -->
+	<project remote="github" name="VictorRodriguez/x.stx-upstream.git"
+		 path="stx-packaging/x.stx-upstream" revision="master"/>
+	<project remote="github" name="marcelarosalesj/x.stx-fault.git"
+		 path="stx-packaging/x.stx-fault" revision="ubuntu" />
+	<project remote="github" name="marcelarosalesj/x.stx-config.git"
+		 path="stx-packaging/x.stx-config" revision="ubuntu" />
+	<project remote="github" name="MarioCarrilloA/x.stx-update.git"
+		 path="stx-packaging/x.stx-update" revision="ubuntu" />
+</manifest>
+

--- a/repos
+++ b/repos
@@ -1,4 +1,0 @@
-https://github.com/VictorRodriguez/x.stx-upstream.git,master
-https://github.com/marcelarosalesj/x.stx-fault.git,ubuntu
-https://github.com/marcelarosalesj/x.stx-config.git,ubuntu
-https://github.com/MarioCarrilloA/x.stx-update.git,ubuntu

--- a/setup.sh
+++ b/setup.sh
@@ -26,38 +26,3 @@ sudo mkdir -p /var/cache/pbuilder/hook.d/
 cp configs/pbuilderrc ~/.pbuilderrc
 sudo cp configs/D70results /var/cache/pbuilder/hook.d/
 
-if [ ! -d "autodeb" ] ; then
-    git clone --depth=1 https://github.com/VictorRodriguez/autodeb.git
-else
-    echo "Updating autodeb"
-    cd autodeb/ && git pull
-    cd ..
-fi
-
-if [ ! -d "linuxbuilder" ] ; then
-    git clone --depth=1 https://github.com/VictorRodriguez/linuxbuilder.git
-else
-    echo "Updating linuxbuilder"
-    cd linuxbuilder/ && git pull
-    cd ..
-fi
-
-if [ ! -d "live_img" ]; then
-    git clone --depth=1 https://github.com/marcelarosalesj/live_img.git
-else
-    echo "Updating live_img"
-    cd live_img/ && git pull
-    cd ..
-fi
-
-# clone source code repos on specific branches
-filename='repos'
-while IFS=, read GIT_REPO BRANCH; do
-	DIR=$(basename $GIT_REPO .git)
-	if [ ! -z $DIR ];then
-		if [ ! -d "$DIR" ] ; then
-			git clone -b $BRANCH --depth=1 $GIT_REPO
-		fi
-	fi
-done < $filename
-echo "Set up complete"


### PR DESCRIPTION
This is a proposal to use `repo` to handle all repositories that needs to be cloned as a requirement. 
The advantage is that we don't need implement any repository management, all can be done with `repo`. 

The drawback is that `repo` needs to be installed prior of cloning this repository. 

Other possible solution would be to use git submodules, however that could add a bit more complexity for developers. 

Signed-off-by: Erich Cordoba <erich.cordoba.malibran@intel.com>