### PR TITLE
Clarify debmake issue due to lack of shebang in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,17 @@ A sanity test is included as well:
 
 This will run the container and execute ./setup.sh && build fm-common
 
+## Known issues
+
+* unknown python version. check setup.py
+
+This is a common error when the setup.py of your source code does not include
+any shebang line. The root cause of this bug release on the debmake file
+[analyze.py](https://salsa.debian.org/debian/debmake/blob/devel/debmake/analyze.py#L302)
+
+A valid workaround is to set a proper shebang into the setup.py of your source
+file in the meantime that we work on a proper patch with debmake maintainer
+
 ## Video Tutorials
 
 [![Audi R8](http://img.youtube.com/vi/YMEOxj8WnKY/0.jpg)](https://www.youtube.com/watch?v=YMEOxj8WnKY "Audi R8")


### PR DESCRIPTION
This patch updates the README file of this project to give a valid
workaround and explain the root cause of the problem. A valid patch will
be sent to the debmake community to address cases where the setup.py does
not have a shebang. In collaboration with the debamake community, we will
try to arrive to the best solution.

Signed-off-by: VictorRodriguez <vm.rod25@gmail.com>