### PR TITLE
Add repos to pbuilderrc file

### DIFF
--- a/configs/pbuilderrc
+++ b/configs/pbuilderrc
@@ -2,7 +2,7 @@
 HOOKDIR="/var/cache/pbuilder/hook.d"
 
 # Path to your local repo to be used as a mirror written as apt source line.
-OTHERMIRROR="deb [trusted=yes] file:///usr/local/mydebs/ ./"
+OTHERMIRROR="deb [trusted=yes] file:///usr/local/mydebs/ ./|deb [trusted=yes] http://archive.ubuntu.com/ubuntu xenial main restricted universe multiverse|deb [trusted=yes] http://ubuntu-cloud.archive.canonical.com/ubuntu xenial-updates/queens main"
 
 # Path to your local repo. This tells pbuilder to mount this directory so it is
 # available in the chroot.


### PR DESCRIPTION
In order to build controllerconfig and sysinv packages, it's
required that the pbuilder chroot has these two repos added.

Signed-off-by: Marcela Rosales <marcelarosalesj@gmail.com>