### PR TITLE
Fix fm-common due to change of repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-PKG ?= "x.stx-fault/fm-common"
+PKG ?= "fault/fm-common"
 DISTRO ?= debian
 ISO_TEMPLATE ?= ""
 BUILD_W_CONT ?= "n"
+NAME ?="fm-common"
+DEBMAKE ?="python"
+SRC_PATH ?="../sources"
 
 
 all:
@@ -25,7 +28,10 @@ build_pkg_native:
 	@echo "Compiing w/o contianers in a native $(DISTRO) system"
 	@echo "Building package $(PKG) for $(DISTRO)"
 ifeq ($(DISTRO),debian)
-	cd $(PKG)/$(DISTRO) && make
+	@if [ ! -f $(PKG)/$(DISTRO)/Makefile ];\
+		then cp configs/debian-flock-Makefile $(PKG)/$(DISTRO)/Makefile;\
+		else echo "Makefile found"; fi
+	cd $(PKG)/$(DISTRO) && make NAME=$(NAME) DEBMAKE=$(DEBMAKE) SRC_PATH=$(SRC_PATH)
 else ifeq ($(DISTRO),centos)
 	cp configs/rpm-Makefile $(PKG)/$(DISTRO)/Makefile
 	cd $(PKG)/$(DISTRO)/ && make MOCK_CONFIG=../../../configs/docker-centos-img/local-centos-7-x86_64.cfg

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Once we have clone the proper repository where the flock service is hosted, we
 can build as:
 
 ```
-make package PKG=x.stx-fault/fm-common DISTRO=debian
+make package PKG=fault/fm-common DISTRO=debian
 ```
 
 	* PKG=path to the directory where our fm-common project lives

--- a/configs/debian-flock-Makefile
+++ b/configs/debian-flock-Makefile
@@ -1,0 +1,13 @@
+all: clean
+	../../../autodeb/autodeb/autodeb -n $(NAME) -b $(DEBMAKE) -p $(SRC_PATH)
+	sudo cp results/*.deb /usr/local/mydebs/
+clean:
+	rm -rf results/
+	rm -rf *.tar.gz
+	rm -rf $(NAME)-0.0/
+	rm -rf *.deb
+	rm -rf *.debian.tar.xz
+	rm -rf *orig.tar.gz
+	rm -rf *.changes
+	rm -rf *.dsc
+	rm -rf *.build

--- a/repos
+++ b/repos
@@ -1,4 +1,4 @@
 https://github.com/VictorRodriguez/x.stx-upstream.git,master
-https://github.com/marcelarosalesj/x.stx-fault.git,debian
+https://opendev.org/starlingx/fault.git,master
 https://github.com/marcelarosalesj/x.stx-config.git,debian
 https://github.com/MarioCarrilloA/x.stx-update.git,debian

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,7 +1,7 @@
 import os
 
 def build_fm_common():
-    ret = os.system("cd ../ && make package PKG=x.stx-fault/fm-common/")
+    ret = os.system("cd ../ && make package PKG=fault/fm-common/")
     return ret
 
 def build_fm_mgr():
@@ -23,14 +23,14 @@ def build_tsconfig():
 def test_fm_common():
     assert build_fm_common() == 0
 
-def test_fm_mgr():
-    assert build_fm_mgr() == 0
+#def test_fm_mgr():
+#    assert build_fm_mgr() == 0
 
-def test_fm_api():
-    assert build_fm_api() == 0
+#def test_fm_api():
+#    assert build_fm_api() == 0
 
-def test_fm_rest_api():
-    assert build_fm_rest_api() == 0
+#def test_fm_rest_api():
+#    assert build_fm_rest_api() == 0
 
-def test_tsconfig():
-    assert build_tsconfig() == 0
+#def test_tsconfig():
+#    assert build_tsconfig() == 0


### PR DESCRIPTION
Due to:

https://review.opendev.org/#/c/662798/
https://review.opendev.org/#/c/662854/
https://review.opendev.org/#/c/662842/

Is necesary to adjust paths and variables and disable:

make fulltest

until the rest of the fault commponents are enable in gerrit upstream

Signed-off-by: VictorRodriguez <vm.rod25@gmail.com>